### PR TITLE
Test clearing a cached value

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -114,6 +114,20 @@ class TestCachedProperty(unittest.TestCase):
         ):
             item.cost
 
+    def test_clear_cached(self):
+        item = CachedCostItem()
+        with self.assertRaises(AttributeError):
+            del item.cost
+        self.assertEqual(item.cost, 2)
+        self.assertEqual(item.cost, 2)
+        del item.cost
+        self.assertEqual(item.cost, 3)
+        self.assertEqual(item.cost, 3)
+        del item.cost
+        with self.assertRaises(AttributeError):
+            del item.cost
+        self.assertEqual(item.cost, 4)
+
     def test_immutable_dict(self):
         class MyMeta(type):
             """Test metaclass."""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a test that verifies that a cached value can be cleared by `del`ing the attribute in the object, in the manner mentioned in the [Python docs](https://docs.python.org/3/library/functools.html#functools.cached_property)

## Are there changes in behavior for the user?

No changes. This just asserts that the functionality that may be expected (it's been documented since Python 3.9) is effectively present

## Related issue number

None

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes

I haven't made any changes to the documentation of this package since the [Python docs](https://docs.python.org/3/library/functools.html#functools.cached_property) already cover this. However, a mention to this feature could be added to the README if that's your preference.
